### PR TITLE
Fixing repo counter

### DIFF
--- a/.github/scripts/count-repos.sh
+++ b/.github/scripts/count-repos.sh
@@ -6,7 +6,7 @@
 EXTRA_IN_JSON_NOT_NAMED_CORRECTLY=4 
 
 # fusionauth-example-template and (temporarily) fusionauth-example-vue-sdk
-EXTRA_IN_GH_NOT_DISPLAYABLE=3
+EXTRA_IN_GH_NOT_DISPLAYABLE=2
 
 cat astro/src/content/json/exampleapps.json|jq '.[]|.url' |sed 's/"//g'|sed 's!https://github.com/!!i' > json.list
 COUNT_IN_JSON=`wc -l json.list |sed 's/^ *//' |sed 's/ .*//'`


### PR DESCRIPTION
After creating the [Rust repo](https://github.com/FusionAuth/fusionauth-quickstart-rust-actix-web), we had to increase an "ignore counter" [in `count-repos.sh`](https://github.com/FusionAuth/fusionauth-site/commit/37134839f0886693a96014ca98787f1968ef2a72), so I'm decreasing this number to pass CI tests