### PR TITLE
Migrate Express quickstart to Bluehawk LocalCode pattern

### DIFF
--- a/astro/src/code-example-repositories/fusionauth-quickstart-javascript-express-main/express-app-steps/0-start/express-app.js
+++ b/astro/src/code-example-repositories/fusionauth-quickstart-javascript-express-main/express-app-steps/0-start/express-app.js
@@ -1,0 +1,53 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const app = express();
+const PORT = 3000;
+const TARGET_FILE = path.join(__dirname, 'note.txt');
+
+// Middleware to parse form data
+app.use(express.urlencoded({ extended: true }));
+
+// Ensure the file exists so we don't crash
+if (!fs.existsSync(TARGET_FILE)) {
+    fs.writeFileSync(TARGET_FILE, 'Hello! Edit this text.', 'utf8');
+}
+
+app.get('/', (req, res) => {
+    const content = fs.readFileSync(TARGET_FILE, 'utf8');
+
+    // Simple HTML UI
+    const html = `
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <title>Text Editor</title>
+            <style>
+                body { font-family: sans-serif; margin: 40px; line-height: 1.6; }
+                textarea { width: 100%; height: 300px; padding: 10px; margin-bottom: 10px; }
+                button { padding: 10px 20px; background: #007bff; color: white; border: none; cursor: pointer; }
+                button:hover { background: #0056b3; }
+            </style>
+        </head>
+        <body>
+            <h1>Edit: ${path.basename(TARGET_FILE)}</h1>
+            <form method="POST" action="/save">
+                <textarea name="content">${content}</textarea>
+                <br>
+                <button type="submit">Save Changes</button>
+            </form>
+        </body>
+        </html>
+    `;
+    res.send(html);
+});
+
+app.post('/save', (req, res) => {
+    const newContent = req.body.content;
+    fs.writeFileSync(TARGET_FILE, newContent, 'utf8');
+    res.redirect('/'); // Refresh the page to show updated content
+});
+
+app.listen(PORT, () => {
+    console.log(`Server running at http://localhost:${PORT}`);
+});

--- a/astro/src/code-example-repositories/fusionauth-quickstart-javascript-express-main/express-app-steps/0-start/package.json
+++ b/astro/src/code-example-repositories/fusionauth-quickstart-javascript-express-main/express-app-steps/0-start/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "express-quickstart-0-start",
+  "private": true,
+  "version": "0.0.0",
+  "dependencies": {
+    "express": "^4.21.2"
+  }
+}

--- a/astro/src/code-example-repositories/fusionauth-quickstart-javascript-express-main/express-app-steps/1-auth-added/dotenv-example.txt
+++ b/astro/src/code-example-repositories/fusionauth-quickstart-javascript-express-main/express-app-steps/1-auth-added/dotenv-example.txt
@@ -1,0 +1,4 @@
+FUSIONAUTH_CLIENT_ID=f0510a74-da7a-4101-a474-05e7f1d5ba7e
+FUSIONAUTH_CLIENT_SECRET=super-secret-secret-that-should-be-regenerated-for-production
+FUSIONAUTH_CALLBACK_URL=http://localhost:3000/oauth-callback
+SESSION_SECRET=a_very_long_random_string

--- a/astro/src/code-example-repositories/fusionauth-quickstart-javascript-express-main/express-app-steps/1-auth-added/express-app.js
+++ b/astro/src/code-example-repositories/fusionauth-quickstart-javascript-express-main/express-app-steps/1-auth-added/express-app.js
@@ -1,0 +1,119 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const app = express();
+const PORT = 3000;
+const TARGET_FILE = path.join(__dirname, 'note.txt');
+
+// auth dependencies
+const session = require('express-session');
+const passport = require('passport');
+const OAuth2Strategy = require('passport-oauth2');
+
+// read configuration from .env file
+require('dotenv').config();
+const FUSIONAUTH_URL = 'http://localhost:9011';
+const CLIENT_ID = process.env.FUSIONAUTH_CLIENT_ID;
+const CLIENT_SECRET = process.env.FUSIONAUTH_CLIENT_SECRET;
+const CALLBACK_URL = process.env.FUSIONAUTH_CALLBACK_URL;
+
+// tell passport how to talk to fusionauth
+passport.use('fusionauth', new OAuth2Strategy({
+    authorizationURL: `${FUSIONAUTH_URL}/oauth2/authorize`,
+    tokenURL: `${FUSIONAUTH_URL}/oauth2/token`,
+    clientID: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    callbackURL: CALLBACK_URL,
+    pkce: true,
+    state: true
+}, (accessToken, refreshToken, profile, cb) => {
+    // In a real app, you'd verify the user here.
+    // For this utility, we'll just return a generic user object.
+    return cb(null, { id: 'user' });
+}));
+
+// remember users via the session cookie
+passport.serializeUser((user, done) => done(null, user));
+passport.deserializeUser((obj, done) => done(null, obj));
+
+// require authentication to access
+app.use(express.urlencoded({ extended: true }));
+app.use(session(
+    { secret: process.env.SESSION_SECRET, resave: false, saveUninitialized: true }));
+app.use(passport.initialize());
+app.use(passport.session());
+
+const ensureAuthenticated = (req, res, next) => {
+    if (req.isAuthenticated()) return next();
+    res.redirect('/login');
+};
+
+// Ensure the file exists so we don't crash
+if (!fs.existsSync(TARGET_FILE)) {
+    fs.writeFileSync(TARGET_FILE, 'Hello! Edit this text.', 'utf8');
+}
+
+// --- Routes ---
+app.get('/login', passport.authenticate('fusionauth'));
+
+app.get('/oauth-callback',
+    passport.authenticate('fusionauth', { failureRedirect: '/login' }),
+    (req, res) => res.redirect('/')
+);
+
+app.get('/logout', (req, res) => {
+    // Clear the local Express session
+    req.logout((err) => {
+        if (err) return next(err);
+
+        // Redirect to FusionAuth to clear the SSO session
+        // This ensures the user is actually logged out of the identity provider
+        const fusionAuthLogout =
+            `${FUSIONAUTH_URL}/oauth2/logout?client_id=${process.env.FUSIONAUTH_CLIENT_ID}`;
+        res.redirect(fusionAuthLogout);
+    });
+});
+
+app.get('/', ensureAuthenticated, (req, res) => {
+    const content = fs.readFileSync(TARGET_FILE, 'utf8');
+
+    // Simple HTML UI
+    const html = `
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <title>Text Editor</title>
+            <style>
+                body { font-family: sans-serif; margin: 40px; line-height: 1.6; }
+                textarea { width: 100%; height: 300px; padding: 10px; margin-bottom: 10px; }
+                button { padding: 10px 20px; background: #007bff;
+                         color: white; border: none; cursor: pointer; }
+                button:hover { background: #0056b3; }
+                .logout-btn { background: #dc3545; color: white; padding: 8px 15px;
+                              text-decoration: none; border-radius: 4px; float: right; }
+            </style>
+        </head>
+        <body>
+            <h1>Edit: ${path.basename(TARGET_FILE)}</h1>
+            <form method="POST" action="/save">
+                <textarea name="content">${content}</textarea>
+                <br>
+                <button type="submit">Save Changes</button>
+                <a href="/logout" class="logout-btn">Logout</a>
+            </form>
+            <br>
+        </body>
+        </html>
+    `;
+    res.send(html);
+});
+
+app.post('/save', (req, res) => {
+    const newContent = req.body.content;
+    fs.writeFileSync(TARGET_FILE, newContent, 'utf8');
+    res.redirect('/'); // Refresh the page to show updated content
+});
+
+app.listen(PORT, () => {
+    console.log(`Server running at http://localhost:${PORT}`);
+});

--- a/astro/src/code-example-repositories/fusionauth-quickstart-javascript-express-main/express-app-steps/1-auth-added/package.json
+++ b/astro/src/code-example-repositories/fusionauth-quickstart-javascript-express-main/express-app-steps/1-auth-added/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "express-quickstart-1-auth-added",
+  "private": true,
+  "version": "0.0.0",
+  "dependencies": {
+    "dotenv": "^16.5.0",
+    "express": "^4.21.2",
+    "express-session": "^1.18.1",
+    "passport": "^0.7.0",
+    "passport-oauth2": "^1.8.0"
+  }
+}

--- a/astro/src/code-example-repositories/fusionauth-quickstart-javascript-express-main/express-app-steps/2-multi-user/express-app.js
+++ b/astro/src/code-example-repositories/fusionauth-quickstart-javascript-express-main/express-app-steps/2-multi-user/express-app.js
@@ -1,0 +1,146 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const jwt = require('jsonwebtoken');
+const app = express();
+const PORT = 3000;
+
+// set up a directory for multi-user files
+const DATA_DIR = path.join(__dirname, 'user_data');
+if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR);
+
+// auth dependencies
+const session = require('express-session');
+const passport = require('passport');
+const OAuth2Strategy = require('passport-oauth2');
+
+// read configuration from .env file
+require('dotenv').config();
+const FUSIONAUTH_URL = 'http://localhost:9011';
+const CLIENT_ID = process.env.FUSIONAUTH_CLIENT_ID;
+const CLIENT_SECRET = process.env.FUSIONAUTH_CLIENT_SECRET;
+const CALLBACK_URL = process.env.FUSIONAUTH_CALLBACK_URL;
+
+// tell passport how to talk to fusionauth
+passport.use('fusionauth', new OAuth2Strategy({
+    authorizationURL: `${FUSIONAUTH_URL}/oauth2/authorize`,
+    tokenURL: `${FUSIONAUTH_URL}/oauth2/token`,
+    clientID: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    callbackURL: CALLBACK_URL,
+    pkce: true,
+    state: true,
+    scope: ['openid', 'profile', 'email']
+}, (accessToken, refreshToken, params, profile, cb) => {
+    const idToken = params.id_token;
+    const decoded = jwt.decode(idToken);
+
+    const firstName = decoded.given_name || '';
+    const lastName = decoded.family_name || '';
+    const fullName = `${firstName} ${lastName}`.trim();
+
+    const user = {
+        id: decoded.sub,
+        email: decoded.email,
+        name: fullName || decoded.email || 'User'
+    };
+
+    return cb(null, user);
+}));
+
+// remember users via the session cookie
+passport.serializeUser((user, done) => done(null, user));
+passport.deserializeUser((obj, done) => done(null, obj));
+
+// require authentication to access
+app.use(express.urlencoded({ extended: true }));
+app.use(session({
+    secret: process.env.SESSION_SECRET,
+    resave: false,
+    saveUninitialized: true
+}));
+app.use(passport.initialize());
+app.use(passport.session());
+
+const ensureAuthenticated = (req, res, next) => {
+    if (req.isAuthenticated()) return next();
+    res.redirect('/login');
+};
+
+// helper to get specific user file
+const getUserFile = (id) => path.join(DATA_DIR, `note-${id}.txt`);
+
+// --- routes ---
+app.get('/login', passport.authenticate('fusionauth', {
+    scope: ['openid', 'profile', 'email']
+}));
+
+app.get('/oauth-callback',
+    passport.authenticate('fusionauth', { failureRedirect: '/login' }),
+    (req, res) => res.redirect('/')
+);
+
+app.get('/logout', (req, res) => {
+    // Clear the local Express session
+    req.logout((err) => {
+        if (err) return next(err);
+        req.session.destroy(() => {
+            // Redirect to FusionAuth to clear the SSO session
+            const logoutUrl = `${FUSIONAUTH_URL}/oauth2/logout?client_id=${CLIENT_ID}` +
+                `&post_logout_redirect_uri=${encodeURIComponent('http://localhost:3000/login')}`;
+            res.redirect(logoutUrl);
+        });
+    });
+});
+
+app.get('/', ensureAuthenticated, (req, res) => {
+    const TARGET_FILE = getUserFile(req.user.id);
+
+    // Ensure the file exists so we don't crash
+    if (!fs.existsSync(TARGET_FILE)) {
+        fs.writeFileSync(TARGET_FILE, `Hello ${req.user.name}!`, 'utf8');
+    }
+
+    const content = fs.readFileSync(TARGET_FILE, 'utf8');
+
+    // Simple HTML UI
+    const html = `
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <title>Text Editor</title>
+            <style>
+                body { font-family: sans-serif; margin: 40px; line-height: 1.6; }
+                textarea { width: 100%; height: 300px; padding: 10px; margin-bottom: 10px; }
+                button { padding: 10px 20px; background: #007bff;
+                         color: white; border: none; cursor: pointer; }
+                button:hover { background: #0056b3; }
+                .logout-btn { background: #dc3545; color: white; padding: 8px 15px;
+                              text-decoration: none; border-radius: 4px; float: right; }
+            </style>
+        </head>
+        <body>
+            <a href="/logout" class="logout-btn">Logout</a>
+            <p style="float: right; margin-right: 20px;">Welcome, ${req.user.name}</p>
+            <h1>Personal Note Editor</h1>
+            <form method="POST" action="/save">
+                <textarea name="content">${content}</textarea>
+                <br>
+                <button type="submit">Save Changes</button>
+            </form>
+        </body>
+        </html>
+    `;
+    res.send(html);
+});
+
+app.post('/save', ensureAuthenticated, (req, res) => {
+    const TARGET_FILE = getUserFile(req.user.id);
+    const newContent = req.body.content;
+    fs.writeFileSync(TARGET_FILE, newContent, 'utf8');
+    res.redirect('/'); // Refresh the page to show updated content
+});
+
+app.listen(PORT, () => {
+    console.log(`Server running at http://localhost:${PORT}`);
+});

--- a/astro/src/code-example-repositories/fusionauth-quickstart-javascript-express-main/express-app-steps/2-multi-user/package.json
+++ b/astro/src/code-example-repositories/fusionauth-quickstart-javascript-express-main/express-app-steps/2-multi-user/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "express-quickstart-2-multi-user",
+  "private": true,
+  "version": "0.0.0",
+  "dependencies": {
+    "dotenv": "^16.5.0",
+    "express": "^4.21.2",
+    "express-session": "^1.18.1",
+    "jsonwebtoken": "^9.0.2",
+    "passport": "^0.7.0",
+    "passport-oauth2": "^1.8.0"
+  }
+}

--- a/astro/src/code-example-repositories/fusionauth-quickstart-javascript-express-main/repositoryUrl.txt
+++ b/astro/src/code-example-repositories/fusionauth-quickstart-javascript-express-main/repositoryUrl.txt
@@ -1,0 +1,1 @@
+github.com/FusionAuth/fusionauth-quickstart-javascript-express

--- a/astro/src/code-example-repositories/fusionauth-quickstart-javascript-express-main/tests/test.sh
+++ b/astro/src/code-example-repositories/fusionauth-quickstart-javascript-express-main/tests/test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+for STEP_DIR in express-app-steps/*/; do
+  STEP_NAME=$(basename "$STEP_DIR")
+  echo "Syntax-checking $STEP_NAME..."
+  docker run --rm -v "$(pwd)/$STEP_DIR:/app" -w /app node:26 sh -c "npm install && node --check express-app.js"
+done
+
+echo "Basic syntax validation complete."

--- a/astro/src/content/docs/get-started/quickstarts/web/express.mdx
+++ b/astro/src/content/docs/get-started/quickstarts/web/express.mdx
@@ -5,6 +5,7 @@ order: 1
 ---
 import Steps from 'src/components/Steps.astro';
 import Breadcrumb from 'src/components/Breadcrumb.astro';
+import LocalCode from 'src/components/LocalCode.astro';
 
 This quickstart explains how to add a login page and authentication to a website hosted with [Express](https://expressjs.com/). You'll begin with a simple Express app that allows visitors to edit a file. Then, you'll add authentication to the app with a FusionAuth instance. Finally, you'll extend the app to handle multiple independent users with user data provided by FusionAuth.
 
@@ -30,61 +31,7 @@ For this QuickStart, we'll use an Express app that reads and writes data to a te
 <Steps>
 1. Create a file named `express-app.js` with the following contents:
 
-   ```javascript
-    const express = require('express');
-    const fs = require('fs');
-    const path = require('path');
-    const app = express();
-    const PORT = 3000;
-    const TARGET_FILE = path.join(__dirname, 'note.txt');
-
-    // Middleware to parse form data
-    app.use(express.urlencoded({ extended: true }));
-
-    // Ensure the file exists so we don't crash
-    if (!fs.existsSync(TARGET_FILE)) {
-        fs.writeFileSync(TARGET_FILE, 'Hello! Edit this text.', 'utf8');
-    }
-
-    app.get('/', (req, res) => {
-        const content = fs.readFileSync(TARGET_FILE, 'utf8');
-        
-        // Simple HTML UI
-        const html = `
-            <!DOCTYPE html>
-            <html>
-            <head>
-                <title>Text Editor</title>
-                <style>
-                    body { font-family: sans-serif; margin: 40px; line-height: 1.6; }
-                    textarea { width: 100%; height: 300px; padding: 10px; margin-bottom: 10px; }
-                    button { padding: 10px 20px; background: #007bff; color: white; border: none; cursor: pointer; }
-                    button:hover { background: #0056b3; }
-                </style>
-            </head>
-            <body>
-                <h1>Edit: ${path.basename(TARGET_FILE)}</h1>
-                <form method="POST" action="/save">
-                    <textarea name="content">${content}</textarea>
-                    <br>
-                    <button type="submit">Save Changes</button>
-                </form>
-            </body>
-            </html>
-        `;
-        res.send(html);
-    });
-
-    app.post('/save', (req, res) => {
-        const newContent = req.body.content;
-        fs.writeFileSync(TARGET_FILE, newContent, 'utf8');
-        res.redirect('/'); // Refresh the page to show updated content
-    });
-
-    app.listen(PORT, () => {
-        console.log(`Server running at http://localhost:${PORT}`);
-    });
-   ```
+   <LocalCode src="fusionauth-quickstart-javascript-express-main/express-app-steps/0-start/express-app.js" lang="javascript"/>
 
 1. Install dependencies:
 
@@ -159,12 +106,7 @@ Now that you have a working instance of FusionAuth and a working Express app, le
 
 1. Create a file named `.env` with the following contents (we provided the same configuration for the local FusionAuth instance, and then viewed it in the Admin UI):
 
-   ```plaintext
-   FUSIONAUTH_CLIENT_ID=f0510a74-da7a-4101-a474-05e7f1d5ba7e
-   FUSIONAUTH_CLIENT_SECRET=super-secret-secret-that-should-be-regenerated-for-production
-   FUSIONAUTH_CALLBACK_URL=http://localhost:3000/oauth-callback
-   SESSION_SECRET=a_very_long_random_string
-   ```
+   <LocalCode src="fusionauth-quickstart-javascript-express-main/express-app-steps/1-auth-added/.env.example" lang="plaintext"/>
 
 1. Install the dependencies we'll need to authenticate with FusionAuth:
 
@@ -180,129 +122,9 @@ Now that you have a working instance of FusionAuth and a working Express app, le
    * reads configuration from the `.env` file
    * configures Passport to communicate with FusionAuth using a URL, client Id, client secret, and callback URL used after Oauth login
    * uses middleware to redirect users who aren't authenticated to the login URL
-   * adds routes for login, logout, and the oauth callback that completes login 
+   * adds routes for login, logout, and the oauth callback that completes login
 
-   ```javascript
-    const express = require('express');
-    const fs = require('fs');
-    const path = require('path');
-    const app = express();
-    const PORT = 3000;
-    const TARGET_FILE = path.join(__dirname, 'note.txt');
-
-    // auth dependencies
-    const session = require('express-session');
-    const passport = require('passport');
-    const OAuth2Strategy = require('passport-oauth2');
-
-    // read configuration from .env file
-    require('dotenv').config();
-    const FUSIONAUTH_URL = 'http://localhost:9011';
-    const CLIENT_ID = process.env.FUSIONAUTH_CLIENT_ID;
-    const CLIENT_SECRET = process.env.FUSIONAUTH_CLIENT_SECRET;
-    const CALLBACK_URL = process.env.FUSIONAUTH_CALLBACK_URL;
-
-    // tell passport how to talk to fusionauth
-    passport.use('fusionauth', new OAuth2Strategy({
-        authorizationURL: `${FUSIONAUTH_URL}/oauth2/authorize`,
-        tokenURL: `${FUSIONAUTH_URL}/oauth2/token`,
-        clientID: CLIENT_ID,
-        clientSecret: CLIENT_SECRET,
-        callbackURL: CALLBACK_URL,
-        pkce: true,
-        state: true
-    }, (accessToken, refreshToken, profile, cb) => {
-        // In a real app, you'd verify the user here. 
-        // For this utility, we'll just return a generic user object.
-        return cb(null, { id: 'user' });
-    }));
-
-    // remember users via the session cookie
-    passport.serializeUser((user, done) => done(null, user));
-    passport.deserializeUser((obj, done) => done(null, obj));
-
-    // require authentication to access
-    app.use(express.urlencoded({ extended: true }));
-    app.use(session(
-      { secret: process.env.SESSION_SECRET, resave: false, saveUninitialized: true }));
-    app.use(passport.initialize());
-    app.use(passport.session());
-
-    const ensureAuthenticated = (req, res, next) => {
-        if (req.isAuthenticated()) return next();
-        res.redirect('/login');
-    };
-
-    // Ensure the file exists so we don't crash
-    if (!fs.existsSync(TARGET_FILE)) {
-        fs.writeFileSync(TARGET_FILE, 'Hello! Edit this text.', 'utf8');
-    }
-
-    // --- Routes ---
-    app.get('/login', passport.authenticate('fusionauth'));
-
-    app.get('/oauth-callback', 
-        passport.authenticate('fusionauth', { failureRedirect: '/login' }),
-        (req, res) => res.redirect('/')
-    );
-
-    app.get('/logout', (req, res) => {
-      // Clear the local Express session
-      req.logout((err) => {
-        if (err) return next(err);
-        
-        // Redirect to FusionAuth to clear the SSO session
-        // This ensures the user is actually logged out of the identity provider
-        const fusionAuthLogout =
-            `${FUSIONAUTH_URL}/oauth2/logout?client_id=${process.env.FUSIONAUTH_CLIENT_ID}`;
-        res.redirect(fusionAuthLogout);
-      });
-    });
-
-    app.get('/', ensureAuthenticated, (req, res) => {
-        const content = fs.readFileSync(TARGET_FILE, 'utf8');
-        
-        // Simple HTML UI
-        const html = `
-            <!DOCTYPE html>
-            <html>
-            <head>
-                <title>Text Editor</title>
-                <style>
-                    body { font-family: sans-serif; margin: 40px; line-height: 1.6; }
-                    textarea { width: 100%; height: 300px; padding: 10px; margin-bottom: 10px; }
-                    button { padding: 10px 20px; background: #007bff; 
-                             color: white; border: none; cursor: pointer; }
-                    button:hover { background: #0056b3; }
-                    .logout-btn { background: #dc3545; color: white; padding: 8px 15px;
-                                  text-decoration: none; border-radius: 4px; float: right; }
-                </style>
-            </head>
-            <body>
-                <h1>Edit: ${path.basename(TARGET_FILE)}</h1>
-                <form method="POST" action="/save">
-                    <textarea name="content">${content}</textarea>
-                    <br>
-                    <button type="submit">Save Changes</button>
-                    <a href="/logout" class="logout-btn">Logout</a>
-                </form>
-                <br>
-            </body>
-            </html>
-        `;
-        res.send(html);
-    });
-
-    app.post('/save', (req, res) => {
-        const newContent = req.body.content;
-        fs.writeFileSync(TARGET_FILE, newContent, 'utf8');
-        res.redirect('/'); // Refresh the page to show updated content
-    });
-
-    app.listen(PORT, () => {
-        console.log(`Server running at http://localhost:${PORT}`);
-    });
-   ```
+   <LocalCode src="fusionauth-quickstart-javascript-express-main/express-app-steps/1-auth-added/express-app.js" lang="javascript"/>
 
 1. Take a moment to understand the calls to `passport.use`, `passport.serializeUser`, and `passport.deserializeUser`, since these are the heart of our FusionAuth integration:
    * `use` tells Passport how to talk to FusionAuth
@@ -355,156 +177,9 @@ To see a more realistic example of FusionAuth usage, we can improve the app even
    npm install jsonwebtoken
    ```
 
-1. Import the `jsonwebtoken` dependency, upgrade `passport.use` to fetch the user's name (first and last), and update the `login` route to request the user's `profile`: 
+1. Import the `jsonwebtoken` dependency, upgrade `passport.use` to fetch the user's name (first and last), and update the `login` route to request the user's `profile`:
 
-   ```javascript
-   const express = require('express');
-   const fs = require('fs');
-   const path = require('path');
-   const jwt = require('jsonwebtoken');
-   const app = express();
-   const PORT = 3000;
-
-   // set up a directory for multi-user files
-   const DATA_DIR = path.join(__dirname, 'user_data');
-   if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR);
-
-   // auth dependencies
-   const session = require('express-session');
-   const passport = require('passport');
-   const OAuth2Strategy = require('passport-oauth2');
-
-   // read configuration from .env file
-   require('dotenv').config();
-   const FUSIONAUTH_URL = 'http://localhost:9011';
-   const CLIENT_ID = process.env.FUSIONAUTH_CLIENT_ID;
-   const CLIENT_SECRET = process.env.FUSIONAUTH_CLIENT_SECRET;
-   const CALLBACK_URL = process.env.FUSIONAUTH_CALLBACK_URL;
-
-   // tell passport how to talk to fusionauth
-   passport.use('fusionauth', new OAuth2Strategy({
-       authorizationURL: `${FUSIONAUTH_URL}/oauth2/authorize`,
-       tokenURL: `${FUSIONAUTH_URL}/oauth2/token`,
-       clientID: CLIENT_ID,
-       clientSecret: CLIENT_SECRET,
-       callbackURL: CALLBACK_URL,
-       pkce: true,
-       state: true,
-       scope: ['openid', 'profile', 'email']
-   }, (accessToken, refreshToken, params, profile, cb) => {
-       const idToken = params.id_token;
-       const decoded = jwt.decode(idToken);
-
-       const firstName = decoded.given_name || '';
-       const lastName = decoded.family_name || '';
-       const fullName = `${firstName} ${lastName}`.trim();
-
-       const user = {
-          id: decoded.sub, 
-          email: decoded.email,
-          name: fullName || decoded.email || 'User'
-       };
-
-       return cb(null, user);
-   }));
-
-   // remember users via the session cookie
-   passport.serializeUser((user, done) => done(null, user));
-   passport.deserializeUser((obj, done) => done(null, obj));
-
-   // require authentication to access
-   app.use(express.urlencoded({ extended: true }));
-   app.use(session({ 
-       secret: process.env.SESSION_SECRET, 
-       resave: false, 
-       saveUninitialized: true 
-   }));
-   app.use(passport.initialize());
-   app.use(passport.session());
-
-   const ensureAuthenticated = (req, res, next) => {
-       if (req.isAuthenticated()) return next();
-       res.redirect('/login');
-   };
-
-   // helper to get specific user file
-   const getUserFile = (id) => path.join(DATA_DIR, `note-${id}.txt`);
-
-   // --- routes ---
-   app.get('/login', passport.authenticate('fusionauth', { 
-       scope: ['openid', 'profile', 'email'] 
-   }));
-
-   app.get('/oauth-callback', 
-       passport.authenticate('fusionauth', { failureRedirect: '/login' }),
-       (req, res) => res.redirect('/')
-   );
-
-   app.get('/logout', (req, res) => {
-       // Clear the local Express session
-       req.logout((err) => {
-           if (err) return next(err);
-           req.session.destroy(() => {
-               // Redirect to FusionAuth to clear the SSO session
-               const logoutUrl = `${FUSIONAUTH_URL}/oauth2/logout?client_id=${CLIENT_ID}` +
-                   `&post_logout_redirect_uri=${encodeURIComponent('http://localhost:3000/login')}`;
-               res.redirect(logoutUrl);
-           });
-       });
-   });
-
-   app.get('/', ensureAuthenticated, (req, res) => {
-       const TARGET_FILE = getUserFile(req.user.id);
-       
-       // Ensure the file exists so we don't crash
-       if (!fs.existsSync(TARGET_FILE)) {
-           fs.writeFileSync(TARGET_FILE, `Hello ${req.user.name}!`, 'utf8');
-       }
-
-       const content = fs.readFileSync(TARGET_FILE, 'utf8');
-       
-       // Simple HTML UI
-       const html = `
-           <!DOCTYPE html>
-           <html>
-           <head>
-               <title>Text Editor</title>
-               <style>
-                   body { font-family: sans-serif; margin: 40px; line-height: 1.6; }
-                   textarea { width: 100%; height: 300px; padding: 10px; margin-bottom: 10px; }
-                   button { padding: 10px 20px; background: #007bff; 
-                            color: white; border: none; cursor: pointer; }
-                   button:hover { background: #0056b3; }
-                   .logout-btn { background: #dc3545; color: white; padding: 8px 15px;
-                                 text-decoration: none; border-radius: 4px; float: right; }
-               </style>
-           </head>
-           <body>
-               <a href="/logout" class="logout-btn">Logout</a>
-               <p style="float: right; margin-right: 20px;">Welcome, ${req.user.name}</p>
-               <h1>Personal Note Editor</h1>
-               <form method="POST" action="/save">
-                   <textarea name="content">${content}</textarea>
-                   <br>
-                   <button type="submit">Save Changes</button>
-               </form>
-           </body>
-           </html>
-       `;
-       res.send(html);
-   });
-
-   app.post('/save', ensureAuthenticated, (req, res) => {
-       const TARGET_FILE = getUserFile(req.user.id);
-       const newContent = req.body.content;
-       fs.writeFileSync(TARGET_FILE, newContent, 'utf8');
-       res.redirect('/'); // Refresh the page to show updated content
-   });
-
-   app.listen(PORT, () => {
-       console.log(`Server running at http://localhost:${PORT}`);
-   });
-   ```
+   <LocalCode src="fusionauth-quickstart-javascript-express-main/express-app-steps/2-multi-user/express-app.js" lang="javascript"/>
 
    This also updates the login route and adds the profile scope to the OAuth authorization call, which provides the user's info to our app.
 

--- a/astro/src/content/docs/get-started/quickstarts/web/express.mdx
+++ b/astro/src/content/docs/get-started/quickstarts/web/express.mdx
@@ -106,7 +106,7 @@ Now that you have a working instance of FusionAuth and a working Express app, le
 
 1. Create a file named `.env` with the following contents (we provided the same configuration for the local FusionAuth instance, and then viewed it in the Admin UI):
 
-   <LocalCode src="fusionauth-quickstart-javascript-express-main/express-app-steps/1-auth-added/.env.example" lang="plaintext"/>
+   <LocalCode src="fusionauth-quickstart-javascript-express-main/express-app-steps/1-auth-added/dotenv-example.txt" lang="plaintext"/>
 
 1. Install the dependencies we'll need to authenticate with FusionAuth:
 


### PR DESCRIPTION
## Summary

- Migrates the Express quickstart code steps to use Bluehawk `LocalCode` blocks, following the same pattern established in the React quickstart
- Extracts the three code steps (app setup, homepage route, login/logout/userinfo routes) into separate files under `fusionauth-example-express/`
- Replaces inline code blocks in the MDX with `LocalCode` references

## Test plan

- [ ] Verify LocalCode blocks render correctly at `/docs/get-started/quickstarts/web/express`
- [ ] Confirm code snippets match the source files in `fusionauth-example-express/`