### PR TITLE
Go API quickstart: Bluehawk migration

### DIFF
--- a/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/.github/CODEOWNERS
+++ b/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# This is a managed file. Manual changes will be overwritten.
+# https://github.com/FusionAuth/fusionauth-public-repos/
+
+.github/ @fusionauth/owners @fusionauth/platform

--- a/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/.github/dependabot.yml
+++ b/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "docker" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/.gitignore
+++ b/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/.gitignore
@@ -1,0 +1,21 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work

--- a/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/README.md
+++ b/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/README.md
@@ -1,0 +1,85 @@
+# Quickstart: Go Resource Server with FusionAuth
+
+This repository contains a Go application that works with a locally-running instance of [FusionAuth](https://fusionauth.io/), the authentication and authorization platform.
+
+## Setup
+
+### Prerequisites
+You will need the following things properly installed on your computer.
+
+* [Git](http://git-scm.com/): Presumably you already have this on your machine if you are looking at this project locally; if not, use your platform's package manager to install git, and `git clone` this repo.
+* [Go](https://go.dev/): You can download and from the go website if it is not already installed on your maching.
+* [Docker](https://www.docker.com): For standing up FusionAuth from within a Docker container. (You can [install it other ways](https://fusionauth.io/docs/v1/tech/installation-guide/), but for this example we will assume you are using Docker.)
+
+This app was built using Go 1.21.0. This example may work on different versions of Go, but it has not been tested.
+
+### FusionAuth Installation via Docker
+
+The root of this project directory (next to this README) are two files [a Docker compose file](./docker-compose.yml) and an [environment variables configuration file](./.env). Assuming you have Docker installed on your machine, you can stand up FusionAuth up on your machine with:
+
+```
+docker compose up -d
+```
+
+The FusionAuth configuration files also make use of a unique feature of FusionAuth, called [Kickstart](https://fusionauth.io/docs/v1/tech/installation-guide/kickstart): when FusionAuth comes up for the first time, it will look at the [Kickstart file](./kickstart/kickstart.json) and mimic API calls to configure FusionAuth for use when it is first run.
+
+> **NOTE**: If you ever want to reset the FusionAuth system, delete the volumes created by docker-compose by executing `docker-compose down -v`.
+
+FusionAuth will be initially configured with these settings:
+
+* Your client Id is: `e9fdb985-9173-4e01-9d73-ac2d60d1dc8e`
+* Your client secret is: `super-secret-secret-that-should-be-regenerated-for-production`
+* Your admin username is `admin@example.com` and your password is `password`.
+* Your teller username is `teller@example.com` and your password is `password`.
+* Your customer username is `customer@example.com` and your password is `password`.
+* Your fusionAuthBaseUrl is 'http://localhost:9011/'
+
+You can log into the [FusionAuth admin UI](http://localhost:9011/admin) and look around if you want, but with Docker/Kickstart you don't need to.
+
+### Go API complete-application
+
+The `complete-application` directory contains a minimal Go app configured to authenticate with locally running FusionAuth.
+
+Install the dependencies and run the app server with:
+```
+cd complete-application
+go get
+go run main.go
+```
+
+Go is now serving two api endpoints
+ - [http://localhost:9001/make-change](http://localhost:9001/make-change) - this endpoint calculates the change to make from a given total
+ - [http://localhost:9001/panic](http://localhost:9001/panic) - this endpoint simulates notifying the police of an incident.
+
+You can login with a user preconfigured during Kickstart, `teller@example.com` with the password of `password` and `applicationId` by calling:
+
+```sh
+curl --location 'https://local.fusionauth.io/api/login' \
+--header 'Authorization: this_really_should_be_a_long_random_alphanumeric_value_but_this_still_works' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+  "loginId": "teller@example.com",
+  "password": "password",
+  "applicationId": "e9fdb985-9173-4e01-9d73-ac2d60d1dc8e"
+}'
+```
+
+You can take the token from the response and then call one of the endpoints listed above by calling:
+
+```sh
+curl --location 'http://localhost:9001/make-change?total=5.12' \
+--header 'Authorization: Bearer {replaceWithToken}'
+```
+
+or
+
+```sh
+curl --location --request POST 'http://localhost:9001/panic' \
+--header 'Authorization: Bearer {replaceWithToken}'
+```
+
+
+
+### Further Information
+
+Visit [https://fusionauth.io/docs/quickstarts/quickstart-go-api](https://fusionauth.io/docs/quickstarts/quickstart-golang-api) for a step-by-step guide on how to build this Go API from scratch.

--- a/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/SECURITY.md
+++ b/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/SECURITY.md
@@ -1,0 +1,3 @@
+# Security Policy
+
+To responsibly report security vulnerabilities, please submit them through our Vulnerability Disclosure Program at <https://fusionauth.io/security>.

--- a/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/complete-application/go.mod
+++ b/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/complete-application/go.mod
@@ -1,0 +1,8 @@
+module complete-application
+
+go 1.21.0
+
+require (
+	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/golang-jwt/jwt/v4 v4.5.0
+)

--- a/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/complete-application/go.sum
+++ b/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/complete-application/go.sum
@@ -1,0 +1,4 @@
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
+github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=

--- a/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/complete-application/main.go
+++ b/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/complete-application/main.go
@@ -1,0 +1,285 @@
+// :snippet-start: package-imports
+package main
+
+import (
+  "crypto/rsa"
+  "encoding/json"
+  "errors"
+  "fmt"
+  "io"
+  "log"
+  "math"
+  "net/http"
+  "reflect"
+  "runtime"
+  "sort"
+  "strconv"
+  "strings"
+
+  "github.com/golang-jwt/jwt/v4"
+)
+
+// :snippet-end:
+
+// :snippet-start: define-struct
+type ChangeResponse struct {
+  Message string
+  Change  []DenominationCounter
+}
+
+type DenominationCounter struct {
+  Denomination string
+  Count        int
+}
+
+// :snippet-end:
+
+// :snippet-start: verify-key
+var verifyKey *rsa.PublicKey
+
+// :snippet-end:
+
+// :snippet-start: main
+func main() {
+  fmt.Println("server")
+  handleRequests()
+}
+
+// :snippet-end:
+
+// :snippet-start: handlers
+func handleRequests() {
+  http.Handle("/make-change", isAuthorized(makeChange))
+  http.Handle("/panic", isAuthorized(panic))
+  log.Fatal(http.ListenAndServe(":9001", nil))
+}
+
+// :snippet-end:
+
+// :snippet-start: panic-function
+func panic(w http.ResponseWriter, r *http.Request) {
+  message := ""
+  var status int
+
+  switch r.Method {
+  case "POST":
+    message = "We've called the police!"
+    status = http.StatusOK
+  default:
+    message = "Only POST method is supported."
+    status = http.StatusNotImplemented
+  }
+
+  responseObject := make(map[string]string)
+  responseObject["message"] = message
+
+  SetWriterReturn(w, status, responseObject)
+}
+
+// :snippet-end:
+
+// :snippet-start: make-change-function
+func makeChange(w http.ResponseWriter, r *http.Request) {
+  response := ChangeResponse{}
+
+  switch r.Method {
+  case "GET":
+    var total = r.URL.Query().Get("total")
+    var message = "We can make change using"
+    remainingAmount, err := strconv.ParseFloat(total, 64)
+    if err != nil {
+      responseObject := make(map[string]string)
+      responseObject["message"] = "Problem converting the submitted value to a decimal.  Value submitted: " + total
+      SetWriterReturn(w, http.StatusBadRequest, responseObject)
+      return
+    }
+
+    coins := make(map[float64]string)
+    coins[.25] = "quarters"
+    coins[.10] = "dimes"
+    coins[.05] = "nickels"
+    coins[.01] = "pennies"
+
+    //since a map is an unordered list, we need another list to maintain the order
+    denominationOrder := make([]float64, 0, len(coins))
+    for value := range coins {
+      denominationOrder = append(denominationOrder, value)
+    }
+
+    //then we order the list
+    sort.Slice(denominationOrder, func(i, j int) bool {
+      return denominationOrder[i] > denominationOrder[j]
+    })
+
+    //for each coin in the list, we figure out how many will fit into the remainingAmount
+    for counter := range denominationOrder {
+      value := denominationOrder[counter]
+      coinName := coins[value]
+      coinCount := int(remainingAmount / value)
+      remainingAmount -= float64(coinCount) * value
+      //had to add this to help with floating point rounding issues.
+      remainingAmount = math.Round(remainingAmount*100) / 100
+
+      message += " " + strconv.Itoa(coinCount) + " " + coinName
+      denominationCount := DenominationCounter{}
+      denominationCount.Denomination = coinName
+      denominationCount.Count = coinCount
+      response.Change = append(response.Change, denominationCount)
+    }
+    response.Message = message
+
+    SetWriterReturn(w, http.StatusOK, response)
+
+  default:
+    responseObject := make(map[string]string)
+    responseObject["message"] = "Only GET method is supported."
+    SetWriterReturn(w, http.StatusNotImplemented, responseObject)
+  }
+
+}
+
+// :snippet-end:
+
+// :snippet-start: authorization
+func isAuthorized(endpoint func(http.ResponseWriter, *http.Request)) http.Handler {
+  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    reqToken := ""
+    tokenCookie, err := r.Cookie("app.at")
+    if err != nil {
+      if errors.Is(err, http.ErrNoCookie) {
+        reqToken = r.Header.Get("Authorization")
+        splitToken := strings.Split(reqToken, "Bearer ")
+        reqToken = splitToken[1]
+      }
+    } else {
+      reqToken = tokenCookie.Value
+    }
+
+    responseObject := make(map[string]string)
+    if reqToken == "" {
+      responseObject["message"] = "No Token provided"
+      SetWriterReturn(w, http.StatusUnauthorized, responseObject)
+    } else {
+      token, err := jwt.Parse(reqToken, func(token *jwt.Token) (interface{}, error) {
+        if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+          return nil, fmt.Errorf(("invalid signing method"))
+        }
+        aud := "e9fdb985-9173-4e01-9d73-ac2d60d1dc8e"
+        checkAudience := token.Claims.(jwt.MapClaims).VerifyAudience(aud, false)
+        if !checkAudience {
+          return nil, fmt.Errorf(("invalid aud"))
+        }
+        // verify iss claim
+        iss := "http://localhost:9011"
+        checkIss := token.Claims.(jwt.MapClaims).VerifyIssuer(iss, false)
+        if !checkIss {
+          return nil, fmt.Errorf(("invalid iss"))
+        }
+
+        setPublicKey(token.Header["kid"].(string))
+        return verifyKey, nil
+      })
+      if err != nil {
+        fmt.Fprint(w, err.Error())
+        return
+      }
+
+      if token.Valid {
+        var roles = token.Claims.(jwt.MapClaims)["roles"]
+        var validRoles []string
+
+        switch pageToGet := GetFunctionName((endpoint)); pageToGet {
+        case "main.panic":
+          validRoles = []string{"teller"}
+        case "main.makeChange":
+          validRoles = []string{"customer", "teller"}
+        }
+
+        result := containsRole([]string{roles.([]interface{})[0].(string)}, validRoles)
+
+        if len(result) > 0 {
+          endpoint(w, r)
+        } else {
+          responseObject := make(map[string]string)
+          responseObject["message"] = "Proper role not found for user"
+          SetWriterReturn(w, http.StatusUnauthorized, responseObject)
+        }
+
+      }
+
+    }
+  })
+}
+
+// :snippet-end:
+
+// :snippet-start: set-public-key
+func setPublicKey(kid string) {
+  if verifyKey == nil {
+    response, err := http.Get("http://localhost:9011/api/jwt/public-key?kid=" + kid)
+    if err != nil {
+      log.Fatalln(err)
+    }
+
+    responseData, err := io.ReadAll(response.Body)
+    if err != nil {
+      log.Fatal(err)
+    }
+
+    var publicKey map[string]interface{}
+
+    json.Unmarshal(responseData, &publicKey)
+
+    var publicKeyPEM = publicKey["publicKey"].(string)
+
+    var verifyBytes = []byte(publicKeyPEM)
+    verifyKey, err = jwt.ParseRSAPublicKeyFromPEM(verifyBytes)
+
+    if err != nil {
+      log.Fatalln(("problem retreiving public key"))
+    }
+  }
+}
+
+// :snippet-end:
+
+// :snippet-start: contains-role
+// function for finding the intersection of two arrays
+func containsRole(roles []string, rolesToCheck []string) []string {
+  intersection := make([]string, 0)
+
+  set := make(map[string]bool)
+
+  // Create a set from the first array
+  for _, role := range roles {
+    set[role] = true // setting the initial value to true
+  }
+
+  // Check elements in the second array against the set
+  for _, role := range rolesToCheck {
+    if set[role] {
+      intersection = append(intersection, role)
+    }
+  }
+
+  return intersection
+}
+
+// :snippet-end:
+
+// :snippet-start: helper
+func GetFunctionName(i interface{}) string {
+  return runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
+}
+
+func SetWriterReturn(w http.ResponseWriter, statusCode int, returnObject interface{}) {
+  w.Header().Set("Content-Type", "application/json")
+  w.WriteHeader(statusCode)
+  jsonResp, err := json.Marshal(returnObject)
+  if err != nil {
+    log.Fatalf("Error happened in JSON marshal. Err: %s", err)
+  }
+  w.Write(jsonResp)
+}
+
+// :snippet-end:

--- a/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/docker-compose.yml
+++ b/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/docker-compose.yml
@@ -1,0 +1,87 @@
+services:
+  db:
+    image: postgres:16.0-bookworm
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - db_net
+    restart: unless-stopped
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  search:
+    image: opensearchproject/opensearch:2.11.0
+    environment:
+      cluster.name: fusionauth
+      discovery.type: single-node
+      node.name: search
+      plugins.security.disabled: true
+      bootstrap.memory_lock: true
+      OPENSEARCH_JAVA_OPTS: ${OPENSEARCH_JAVA_OPTS}
+    healthcheck:
+      interval: 10s
+      retries: 80
+      test: curl --write-out 'HTTP %{http_code}' --fail --silent --output /dev/null http://localhost:9200/
+    restart: unless-stopped
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    ports:
+      - 9200:9200 # REST API
+      - 9600:9600 # Performance Analyzer
+    volumes:
+      - search_data:/usr/share/opensearch/data
+    networks:
+      - search_net
+
+  fusionauth:
+    image: fusionauth/fusionauth-app:latest
+    depends_on:
+      db:
+        condition: service_healthy
+      search:
+        condition: service_healthy
+    environment:
+      DATABASE_PASSWORD: ${DATABASE_PASSWORD}
+      DATABASE_ROOT_PASSWORD: ${POSTGRES_PASSWORD}
+      DATABASE_ROOT_USERNAME: ${POSTGRES_USER}
+      DATABASE_URL: jdbc:postgresql://db:5432/fusionauth
+      DATABASE_USERNAME: ${DATABASE_USERNAME}
+      FUSIONAUTH_APP_INSTALLATION_SOURCE: fusionauth-quickstart-golang-api
+      FUSIONAUTH_APP_KICKSTART_FILE: ${FUSIONAUTH_APP_KICKSTART_FILE}
+      FUSIONAUTH_APP_MEMORY: ${FUSIONAUTH_APP_MEMORY}
+      FUSIONAUTH_APP_RUNTIME_MODE: ${FUSIONAUTH_APP_RUNTIME_MODE}
+      FUSIONAUTH_APP_URL: http://fusionauth:9011
+      SEARCH_SERVERS: http://search:9200
+      SEARCH_TYPE: elasticsearch
+    networks:
+      - db_net
+      - search_net
+    restart: unless-stopped
+    ports:
+      - 9011:9011
+    volumes:
+      - fusionauth_config:/usr/local/fusionauth/config
+      - ./kickstart:/usr/local/fusionauth/kickstart
+
+networks:
+  db_net:
+    driver: bridge
+  search_net:
+    driver: bridge
+
+volumes:
+  db_data:
+  fusionauth_config:
+  search_data:

--- a/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/kickstart/kickstart.json
+++ b/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/kickstart/kickstart.json
@@ -1,0 +1,175 @@
+{
+  "variables": {
+    "applicationId": "e9fdb985-9173-4e01-9d73-ac2d60d1dc8e",
+    "apiKey": "this_really_should_be_a_long_random_alphanumeric_value_but_this_still_works",
+    "asymmetricKeyId": "#{UUID()}",
+    "defaultTenantId": "d7d09513-a3f5-401c-9685-34ab6c552453",
+    "adminEmail": "admin@example.com",
+    "adminPassword": "password",
+    "tellerEmail": "teller@example.com",
+    "tellerPassword": "password",
+    "tellerUserId": "00000000-0000-0000-0000-111111111111",
+    "customerEmail": "customer@example.com",
+    "customerPassword": "password",
+    "customerUserId": "00000000-0000-0000-0000-222222222222"
+  },
+  "apiKeys": [
+    {
+      "key": "#{apiKey}",
+      "description": "Unrestricted API key"
+    }
+  ],
+  "requests": [
+    {
+      "method": "PATCH",
+      "body": {
+        "tenant": {
+          "issuer": "http://localhost:9011"
+        }
+      }
+    },
+    {
+      "method": "PATCH",
+      "url": "api/system-configuration",
+      "body": {
+        "systemConfiguration": {
+          "usageDataConfiguration": {
+            "enabled": true
+          }
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/key/generate/#{asymmetricKeyId}",
+      "tenantId": "#{defaultTenantId}",
+      "body": {
+        "key": {
+          "algorithm": "RS256",
+          "name": "For exampleapp",
+          "length": 2048
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/user/registration",
+      "body": {
+        "user": {
+          "email": "#{adminEmail}",
+          "password": "#{adminPassword}"
+        },
+        "registration": {
+          "applicationId": "#{FUSIONAUTH_APPLICATION_ID}",
+          "roles": [
+            "admin"
+          ]
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/application/#{applicationId}",
+      "tenantId": "#{defaultTenantId}",
+      "body": {
+        "application": {
+          "name": "Example app",
+          "oauthConfiguration": {
+            "authorizedRedirectURLs": [],
+            "clientSecret": "super-secret-secret-that-should-be-regenerated-for-production",
+            "logoutURL": "http://localhost:8080/logout",
+            "enabledGrants": [
+              "authorization_code",
+              "refresh_token"
+            ],
+            "proofKeyForCodeExchangePolicy": "Required",
+            "requireRegistration": true
+          },
+          "jwtConfiguration": {
+            "enabled": true,
+            "accessTokenKeyId": "#{asymmetricKeyId}",
+            "idTokenKeyId": "#{asymmetricKeyId}"
+          },
+          "registrationConfiguration": {
+            "birthDate": {
+              "enabled": false,
+              "required": false
+            },
+            "confirmPassword": false,
+            "enabled": true,
+            "firstName": {
+              "enabled": false,
+              "required": false
+            },
+            "fullName": {
+              "enabled": true,
+              "required": true
+            },
+            "lastName": {
+              "enabled": false,
+              "required": false
+            },
+            "loginIdType": "email",
+            "middleName": {
+              "enabled": false,
+              "required": false
+            },
+            "mobilePhone": {
+              "enabled": false,
+              "required": false
+            },
+            "type": "basic"
+          },
+          "roles": [
+            {
+              "name": "teller"
+            },
+            {
+              "name": "customer"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/user/registration/#{tellerUserId}",
+      "body": {
+        "user": {
+          "birthDate": "1985-11-23",
+          "email": "#{tellerEmail}",
+          "firstName": "Tammy",
+          "lastName": "Teller",
+          "fullName": "Tammy Teller",
+          "password": "#{tellerPassword}"
+        },
+        "registration": {
+          "applicationId": "#{applicationId}",
+          "roles": [
+            "teller"
+          ]
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/user/registration/#{customerUserId}",
+      "body": {
+        "user": {
+          "birthDate": "1985-11-23",
+          "email": "#{customerEmail}",
+          "firstName": "Charlie",
+          "lastName": "Customer",
+          "fullName": "Charlie Customer",
+          "password": "#{customerPassword}"
+        },
+        "registration": {
+          "applicationId": "#{applicationId}",
+          "roles": [
+            "customer"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/tests/test.sh
+++ b/astro/src/code-example-repositories/fusionauth-quickstart-golang-api-main/tests/test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Validating docker compose config..."
+docker compose -f docker-compose.yml config > /dev/null
+
+echo "Building Go application..."
+docker run --rm -v "$(pwd)/complete-application:/app" -w /app golang:1.21 go build ./...
+
+echo "All tests passed."

--- a/astro/src/content/docs/get-started/quickstarts/api/quickstart-golang-api.mdx
+++ b/astro/src/content/docs/get-started/quickstarts/api/quickstart-golang-api.mdx
@@ -8,7 +8,7 @@ import DockerSpinup from 'src/components/quickstarts/DockerSpinup.astro';
 import Intro from 'src/components/quickstarts/Intro.astro';
 import {Content as LoginArchitectureApi} from 'src/components/quickstarts/LoginArchitectureApi.mdx';
 import NextStepsApi from 'src/components/quickstarts/NextStepsApi.astro';
-import RemoteCode from 'src/components/RemoteCode.astro';
+import LocalCode from 'src/components/LocalCode.astro';
 import Breadcrumb from 'src/components/Breadcrumb.astro';
 import QuickstartTshirtCTA from 'src/components/quickstarts/QuickstartTshirtCTA.astro'
 
@@ -89,40 +89,33 @@ Now you are going to write some Golang code. You need to create a file called `m
 
 Here you will add the package clause and import declarations below:
 
-<RemoteCode url={frontmatter.codeRoot + "/complete-application/main.go"} tags="package-imports"
-  lang="go"/>
+<LocalCode src="fusionauth-quickstart-golang-api-main/main.snippet.package-imports.go" lang="go"/>
 
 Next, you will need to add a couple of structures to help manage the data for making change.
 
-<RemoteCode url={frontmatter.codeRoot + "/complete-application/main.go"} tags="define-struct"
-  lang="go"/>
+<LocalCode src="fusionauth-quickstart-golang-api-main/main.snippet.define-struct.go" lang="go"/>
 
 You will also need to declare a variable and assign the value of the public key for the application. The value for this key will be set later in the application. Declare this variable below the import declarations.
 
-<RemoteCode url={frontmatter.codeRoot + "/complete-application/main.go"} tags="verify-key"
-  lang="go"/>
+<LocalCode src="fusionauth-quickstart-golang-api-main/main.snippet.verify-key.go" lang="go"/>
 
 ### Add Handlers and Functions
 
 Create the main function for the application.
 
-<RemoteCode url={frontmatter.codeRoot + "/complete-application/main.go"} tags="main"
-  lang="go"/>
+<LocalCode src="fusionauth-quickstart-golang-api-main/main.snippet.main.go" lang="go"/>
 
 Next, you are going to add some handlers. This tells the application how to handle specific requests. Notice the `isAuthorized` function wrapping around the `panic` and `makeChange` functions. We will implement this function later and it is what will validate the token and verify the roles. This function will also stand up the HTTP listener on port `9001`.
 
-<RemoteCode url={frontmatter.codeRoot + "/complete-application/main.go"} tags="handlers"
-  lang="go"/>
+<LocalCode src="fusionauth-quickstart-golang-api-main/main.snippet.handlers.go" lang="go"/>
 
 You will write two functions that will return values when users access them. These functions are called by the handlers. One is the `panic` which returns a message when a successful `POST` call is made to `/panic`. This will also display a message if the request is not made through a `POST`. This API has no relation to the `panic` method in go, it's for a teller panicking when ChangeBank is being robbed.
 
-<RemoteCode url={frontmatter.codeRoot + "/complete-application/main.go"} tags="panic-function"
-  lang="go"/>
+<LocalCode src="fusionauth-quickstart-golang-api-main/main.snippet.panic-function.go" lang="go"/>
 
 Next you need a function to show the breakdown from making change for a given dollar amount. This function will get the `total` value from the query string. If the `total` cannot be cast to a `float64`, the function will return a message stating that. If the `total` is a valid number, the function will return the description of the change.
 
-<RemoteCode url={frontmatter.codeRoot + "/complete-application/main.go"} tags="make-change-function"
-  lang="go"/>
+<LocalCode src="fusionauth-quickstart-golang-api-main/main.snippet.make-change-function.go" lang="go"/>
 
 ### Add Security
 
@@ -150,8 +143,7 @@ Now you need to implement the `isAuthorized` function used by the handlers. Now,
 
 You need to validate the token and make sure the user has the appropriate role to access the API. You can do so by adding the following code:
 
-<RemoteCode url={frontmatter.codeRoot + "/complete-application/main.go"} tags="authorization"
-  lang="go"/>
+<LocalCode src="fusionauth-quickstart-golang-api-main/main.snippet.authorization.go" lang="go"/>
 
 There is a lot of code in this function. Let's break it down:
 - First you validate some claims. Notice the `checkAudience` that makes sure the token is intended for this application and `checkIss` to make sure the issuer is as expected.
@@ -168,18 +160,15 @@ Now, you will add the code to set the public key. This function will accept the 
 Different tokens can be signed with different keys. In this example there is only one key used. If the key is already set, the application will not attempt to set it again. In a production environment you could store this key on the server or set it once on initialization. If your API serves several applications, you will need to get the correct public key for each application if the signing keys are different between applications. It should also be noted that you could use [JWKS](/docs/apis/oauth#json-web-key-set-jwks), a standard for retrieving public keys, but this example uses FusionAuth's proprietary APIs.
 </Aside>
 
-<RemoteCode url={frontmatter.codeRoot + "/complete-application/main.go"} tags="set-public-key"
-  lang="go"/>
+<LocalCode src="fusionauth-quickstart-golang-api-main/main.snippet.set-public-key.go" lang="go"/>
 
 Then add the code to compare the required roles to the user's roles based on the token.
 
-<RemoteCode url={frontmatter.codeRoot + "/complete-application/main.go"} tags="contains-role"
-  lang="go"/>
+<LocalCode src="fusionauth-quickstart-golang-api-main/main.snippet.contains-role.go" lang="go"/>
 
 Finally you will add two helper functions. `GetFunctionName` will return the name of the function being called by the endpoint. `SetWriterReturn` will format the response properly.
 
-<RemoteCode url={frontmatter.codeRoot + "/complete-application/main.go"} tags="helper"
-  lang="go"/>
+<LocalCode src="fusionauth-quickstart-golang-api-main/main.snippet.helper.go" lang="go"/>
 
 That is all the code for the sample application. Save the `main.go` file.
 

--- a/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.authorization.go
+++ b/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.authorization.go
@@ -1,0 +1,70 @@
+func isAuthorized(endpoint func(http.ResponseWriter, *http.Request)) http.Handler {
+  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    reqToken := ""
+    tokenCookie, err := r.Cookie("app.at")
+    if err != nil {
+      if errors.Is(err, http.ErrNoCookie) {
+        reqToken = r.Header.Get("Authorization")
+        splitToken := strings.Split(reqToken, "Bearer ")
+        reqToken = splitToken[1]
+      }
+    } else {
+      reqToken = tokenCookie.Value
+    }
+
+    responseObject := make(map[string]string)
+    if reqToken == "" {
+      responseObject["message"] = "No Token provided"
+      SetWriterReturn(w, http.StatusUnauthorized, responseObject)
+    } else {
+      token, err := jwt.Parse(reqToken, func(token *jwt.Token) (interface{}, error) {
+        if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+          return nil, fmt.Errorf(("invalid signing method"))
+        }
+        aud := "e9fdb985-9173-4e01-9d73-ac2d60d1dc8e"
+        checkAudience := token.Claims.(jwt.MapClaims).VerifyAudience(aud, false)
+        if !checkAudience {
+          return nil, fmt.Errorf(("invalid aud"))
+        }
+        // verify iss claim
+        iss := "http://localhost:9011"
+        checkIss := token.Claims.(jwt.MapClaims).VerifyIssuer(iss, false)
+        if !checkIss {
+          return nil, fmt.Errorf(("invalid iss"))
+        }
+
+        setPublicKey(token.Header["kid"].(string))
+        return verifyKey, nil
+      })
+      if err != nil {
+        fmt.Fprint(w, err.Error())
+        return
+      }
+
+      if token.Valid {
+        var roles = token.Claims.(jwt.MapClaims)["roles"]
+        var validRoles []string
+
+        switch pageToGet := GetFunctionName((endpoint)); pageToGet {
+        case "main.panic":
+          validRoles = []string{"teller"}
+        case "main.makeChange":
+          validRoles = []string{"customer", "teller"}
+        }
+
+        result := containsRole([]string{roles.([]interface{})[0].(string)}, validRoles)
+
+        if len(result) > 0 {
+          endpoint(w, r)
+        } else {
+          responseObject := make(map[string]string)
+          responseObject["message"] = "Proper role not found for user"
+          SetWriterReturn(w, http.StatusUnauthorized, responseObject)
+        }
+
+      }
+
+    }
+  })
+}
+

--- a/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.contains-role.go
+++ b/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.contains-role.go
@@ -1,0 +1,21 @@
+// function for finding the intersection of two arrays
+func containsRole(roles []string, rolesToCheck []string) []string {
+  intersection := make([]string, 0)
+
+  set := make(map[string]bool)
+
+  // Create a set from the first array
+  for _, role := range roles {
+    set[role] = true // setting the initial value to true
+  }
+
+  // Check elements in the second array against the set
+  for _, role := range rolesToCheck {
+    if set[role] {
+      intersection = append(intersection, role)
+    }
+  }
+
+  return intersection
+}
+

--- a/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.define-struct.go
+++ b/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.define-struct.go
@@ -1,0 +1,10 @@
+type ChangeResponse struct {
+  Message string
+  Change  []DenominationCounter
+}
+
+type DenominationCounter struct {
+  Denomination string
+  Count        int
+}
+

--- a/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.handlers.go
+++ b/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.handlers.go
@@ -1,0 +1,6 @@
+func handleRequests() {
+  http.Handle("/make-change", isAuthorized(makeChange))
+  http.Handle("/panic", isAuthorized(panic))
+  log.Fatal(http.ListenAndServe(":9001", nil))
+}
+

--- a/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.helper.go
+++ b/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.helper.go
@@ -1,0 +1,14 @@
+func GetFunctionName(i interface{}) string {
+  return runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
+}
+
+func SetWriterReturn(w http.ResponseWriter, statusCode int, returnObject interface{}) {
+  w.Header().Set("Content-Type", "application/json")
+  w.WriteHeader(statusCode)
+  jsonResp, err := json.Marshal(returnObject)
+  if err != nil {
+    log.Fatalf("Error happened in JSON marshal. Err: %s", err)
+  }
+  w.Write(jsonResp)
+}
+

--- a/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.main.go
+++ b/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.main.go
@@ -1,0 +1,5 @@
+func main() {
+  fmt.Println("server")
+  handleRequests()
+}
+

--- a/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.make-change-function.go
+++ b/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.make-change-function.go
@@ -1,0 +1,59 @@
+func makeChange(w http.ResponseWriter, r *http.Request) {
+  response := ChangeResponse{}
+
+  switch r.Method {
+  case "GET":
+    var total = r.URL.Query().Get("total")
+    var message = "We can make change using"
+    remainingAmount, err := strconv.ParseFloat(total, 64)
+    if err != nil {
+      responseObject := make(map[string]string)
+      responseObject["message"] = "Problem converting the submitted value to a decimal.  Value submitted: " + total
+      SetWriterReturn(w, http.StatusBadRequest, responseObject)
+      return
+    }
+
+    coins := make(map[float64]string)
+    coins[.25] = "quarters"
+    coins[.10] = "dimes"
+    coins[.05] = "nickels"
+    coins[.01] = "pennies"
+
+    //since a map is an unordered list, we need another list to maintain the order
+    denominationOrder := make([]float64, 0, len(coins))
+    for value := range coins {
+      denominationOrder = append(denominationOrder, value)
+    }
+
+    //then we order the list
+    sort.Slice(denominationOrder, func(i, j int) bool {
+      return denominationOrder[i] > denominationOrder[j]
+    })
+
+    //for each coin in the list, we figure out how many will fit into the remainingAmount
+    for counter := range denominationOrder {
+      value := denominationOrder[counter]
+      coinName := coins[value]
+      coinCount := int(remainingAmount / value)
+      remainingAmount -= float64(coinCount) * value
+      //had to add this to help with floating point rounding issues.
+      remainingAmount = math.Round(remainingAmount*100) / 100
+
+      message += " " + strconv.Itoa(coinCount) + " " + coinName
+      denominationCount := DenominationCounter{}
+      denominationCount.Denomination = coinName
+      denominationCount.Count = coinCount
+      response.Change = append(response.Change, denominationCount)
+    }
+    response.Message = message
+
+    SetWriterReturn(w, http.StatusOK, response)
+
+  default:
+    responseObject := make(map[string]string)
+    responseObject["message"] = "Only GET method is supported."
+    SetWriterReturn(w, http.StatusNotImplemented, responseObject)
+  }
+
+}
+

--- a/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.package-imports.go
+++ b/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.package-imports.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+  "crypto/rsa"
+  "encoding/json"
+  "errors"
+  "fmt"
+  "io"
+  "log"
+  "math"
+  "net/http"
+  "reflect"
+  "runtime"
+  "sort"
+  "strconv"
+  "strings"
+
+  "github.com/golang-jwt/jwt/v4"
+)
+

--- a/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.panic-function.go
+++ b/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.panic-function.go
@@ -1,0 +1,19 @@
+func panic(w http.ResponseWriter, r *http.Request) {
+  message := ""
+  var status int
+
+  switch r.Method {
+  case "POST":
+    message = "We've called the police!"
+    status = http.StatusOK
+  default:
+    message = "Only POST method is supported."
+    status = http.StatusNotImplemented
+  }
+
+  responseObject := make(map[string]string)
+  responseObject["message"] = message
+
+  SetWriterReturn(w, status, responseObject)
+}
+

--- a/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.set-public-key.go
+++ b/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.set-public-key.go
@@ -1,0 +1,27 @@
+func setPublicKey(kid string) {
+  if verifyKey == nil {
+    response, err := http.Get("http://localhost:9011/api/jwt/public-key?kid=" + kid)
+    if err != nil {
+      log.Fatalln(err)
+    }
+
+    responseData, err := io.ReadAll(response.Body)
+    if err != nil {
+      log.Fatal(err)
+    }
+
+    var publicKey map[string]interface{}
+
+    json.Unmarshal(responseData, &publicKey)
+
+    var publicKeyPEM = publicKey["publicKey"].(string)
+
+    var verifyBytes = []byte(publicKeyPEM)
+    verifyKey, err = jwt.ParseRSAPublicKeyFromPEM(verifyBytes)
+
+    if err != nil {
+      log.Fatalln(("problem retreiving public key"))
+    }
+  }
+}
+

--- a/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.verify-key.go
+++ b/astro/src/generated-code-snippets/fusionauth-quickstart-golang-api-main/main.snippet.verify-key.go
@@ -1,0 +1,2 @@
+var verifyKey *rsa.PublicKey
+


### PR DESCRIPTION
## Summary

- Cloned the FusionAuth Go API example repo and added as a local submodule reference
- Converted AsciiDoc snippet tags to Bluehawk tags across the Go source files
- Generated 11 Bluehawk snippets
- Replaced all RemoteCode blocks in the Go API quickstart MDX with LocalCode blocks

## Test plan

- [ ] Verify Bluehawk snippets render correctly in local preview
- [ ] Confirm all 11 code blocks display expected Go source