### PR TITLE
fix: explorer navbar z-index, download links, and UX improvements

### DIFF
--- a/astro/scripts/build-openapi.mjs
+++ b/astro/scripts/build-openapi.mjs
@@ -162,7 +162,7 @@ Once you have entered your API key in the **Authentication** panel above:
 - Fill in the required fields and click **Send** to make a live request against your local instance.
 - Use the **Client Libraries** panel to get generated code examples in Shell, Ruby, Node.js, PHP, Python, and more.
 - Deep links work natively. You can share a URL that opens directly to a specific endpoint.
-- Use the **Download OpenAPI Document** link to download the full spec.`;
+- Use the **YAML** or **JSON** links in the toolbar to download the full spec.`;
 
   const out = stringify(spec, { lineWidth: 0 });
   await mkdir(dirname(OUT_PATH), { recursive: true });

--- a/astro/src/content/docs/apis/api-explorer-guide.mdx
+++ b/astro/src/content/docs/apis/api-explorer-guide.mdx
@@ -41,11 +41,10 @@ Once you have entered your API key, you can browse and test any FusionAuth API e
 - Fill in the required fields and click **Send** to make a live request against your local instance.
 - Use the **Client Libraries** panel to get generated code examples in Shell, Ruby, Node.js, PHP, Python, and more.
 - Deep links work natively. You can share a URL that opens directly to a specific endpoint.
-- Use the **Download OpenAPI Document** link to download the full spec.
+- Use the **YAML** or **JSON** links in the toolbar to download the full spec.
 
 ## Versioning
 
 The explorer loads the latest FusionAuth API spec by default. To test against an older version:
 
 - Use the **Version** dropdown at the top of the explorer to select from available releases.
-- Or paste a raw `openapi.yaml` URL directly into the URL input and click **Load**. Raw URLs for any release can be found at [github.com/FusionAuth/fusionauth-openapi/tags](https://github.com/FusionAuth/fusionauth-openapi/tags), for example: `https://raw.githubusercontent.com/FusionAuth/fusionauth-openapi/1.40.0/openapi.yaml`.

--- a/astro/src/pages/docs/apis/api-explorer.astro
+++ b/astro/src/pages/docs/apis/api-explorer.astro
@@ -176,6 +176,13 @@ const description = "Interactive explorer for the FusionAuth API.";
         .api-reference-toolbar { display: none !important; }
         .download-container { display: none !important; }
 
+        .badge {
+          display: inline-flex !important;
+          align-items: center !important;
+          padding: 5px 6px 3px !important;
+          line-height: 1 !important;
+        }
+
         aside.t-doc__sidebar {
           top: 105px !important;
           height: calc(100vh - 105px) !important;

--- a/astro/src/pages/docs/apis/api-explorer.astro
+++ b/astro/src/pages/docs/apis/api-explorer.astro
@@ -87,43 +87,6 @@ const description = "Interactive explorer for the FusionAuth API.";
       color: #94a3b8;
       padding: 0 2px;
     }
-    .version-switcher input[type="text"] {
-      height: 24px;
-      width: 220px;
-      padding: 0 7px;
-      font-size: 12px;
-      border: 1px solid #cbd5e1;
-      border-radius: 4px;
-      background: #f8fafc;
-      color: #0f172a;
-      outline: none;
-    }
-    html.dark .version-switcher input[type="text"] {
-      border-color: #334155;
-      background: #1e293b;
-      color: #f1f5f9;
-    }
-    .version-switcher input[type="text"]:focus {
-      border-color: #f58320;
-      box-shadow: 0 0 0 2px rgba(245, 131, 32, 0.25);
-    }
-    .version-switcher input[type="text"]::placeholder {
-      color: #94a3b8;
-    }
-    .version-switcher button {
-      height: 24px;
-      padding: 0 10px;
-      font-size: 12px;
-      font-weight: 500;
-      border: 1px solid #f58320;
-      border-radius: 4px;
-      background: #f58320;
-      color: #fff;
-      cursor: pointer;
-      white-space: nowrap;
-    }
-    .version-switcher button:hover { background: #e0721a; border-color: #e0721a; }
-
     .download-label {
       font-size: 12px;
       color: inherit;
@@ -152,9 +115,6 @@ const description = "Interactive explorer for the FusionAuth API.";
         <label for="version-select">Version:</label>
         <span id="version-loading" class="loading">Loading…</span>
         <select id="version-select" style="display:none" aria-label="API spec version"></select>
-        <span class="sep">or</span>
-        <input id="spec-url-input" type="text" placeholder="Paste a raw openapi.yaml URL" aria-label="Custom OpenAPI spec URL" />
-        <button id="spec-url-load">Load</button>
         <span class="sep">·</span>
         <span class="download-label">Download:</span>
         <a id="download-yaml" href="#">YAML</a>
@@ -308,8 +268,6 @@ const description = "Interactive explorer for the FusionAuth API.";
       const downloadYaml = document.getElementById('download-yaml');
       const downloadJson = document.getElementById('download-json');
 
-      function updateDownloadLinks() {}
-
       async function triggerDownload(content, filename, type) {
         const blob = new Blob([content], { type });
         const url = URL.createObjectURL(blob);
@@ -338,31 +296,9 @@ const description = "Interactive explorer for the FusionAuth API.";
         triggerDownload(json, filename, 'application/json');
       });
 
-      updateDownloadLinks();
-
       versionSelect.addEventListener('change', () => {
         activeUrl = versionSelect.value;
-        specUrlInput.value = '';
         scalar.updateConfiguration(buildConfig());
-        updateDownloadLinks();
-      });
-
-      // URL input — overrides the dropdown
-      const specUrlInput = document.getElementById('spec-url-input');
-      const specUrlLoad  = document.getElementById('spec-url-load');
-
-      function loadCustomUrl() {
-        const url = specUrlInput.value.trim();
-        if (!url) return;
-        activeUrl = url;
-        versionSelect.value = '';
-        scalar.updateConfiguration(buildConfig());
-        updateDownloadLinks();
-      }
-
-      specUrlLoad.addEventListener('click', loadCustomUrl);
-      specUrlInput.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') loadCustomUrl();
       });
     </script>
   </body>

--- a/astro/src/pages/docs/apis/api-explorer.astro
+++ b/astro/src/pages/docs/apis/api-explorer.astro
@@ -174,7 +174,7 @@ const description = "Interactive explorer for the FusionAuth API.";
       const customCss = `
         .darklight-reference { display: none !important; }
         .api-reference-toolbar { display: none !important; }
-        .scalar-download-button { display: none !important; }
+        .download-container { display: none !important; }
 
         aside.t-doc__sidebar {
           top: 105px !important;

--- a/astro/src/pages/docs/apis/api-explorer.astro
+++ b/astro/src/pages/docs/apis/api-explorer.astro
@@ -124,6 +124,19 @@ const description = "Interactive explorer for the FusionAuth API.";
     }
     .version-switcher button:hover { background: #e0721a; border-color: #e0721a; }
 
+    .download-label {
+      font-size: 12px;
+      color: inherit;
+      white-space: nowrap;
+    }
+    .version-switcher a {
+      font-size: 12px;
+      color: #f58320;
+      text-decoration: none;
+      white-space: nowrap;
+    }
+    .version-switcher a:hover { text-decoration: underline; }
+
     /* ThemeSelector's MoonIcon hardcodes text-white (it lives in the dark
        docs nav by default). On our light topbar that's invisible, so we
        force the icon to inherit the topbar's foreground color. */
@@ -142,6 +155,11 @@ const description = "Interactive explorer for the FusionAuth API.";
         <span class="sep">or</span>
         <input id="spec-url-input" type="text" placeholder="Paste a raw openapi.yaml URL" aria-label="Custom OpenAPI spec URL" />
         <button id="spec-url-load">Load</button>
+        <span class="sep">·</span>
+        <span class="download-label">Download:</span>
+        <a id="download-yaml" href="#">YAML</a>
+        <span class="sep">·</span>
+        <a id="download-json" href="#">JSON</a>
       </div>
       <span class="spacer"></span>
     </nav>
@@ -149,12 +167,14 @@ const description = "Interactive explorer for the FusionAuth API.";
     <div id="scalar-app"></div>
 
     <script is:inline src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+    <script is:inline src="https://cdn.jsdelivr.net/npm/js-yaml@4/dist/js-yaml.min.js"></script>
     <script is:inline>
       // Theme is owned entirely by ThemeSelector + Head.astro's inline script.
       // The single source of truth is `documentElement.classList.contains('dark')`.
       const customCss = `
         .darklight-reference { display: none !important; }
         .api-reference-toolbar { display: none !important; }
+        .scalar-download-button { display: none !important; }
 
         aside.t-doc__sidebar {
           top: 105px !important;
@@ -273,10 +293,47 @@ const description = "Interactive explorer for the FusionAuth API.";
           versionLoading.textContent = 'Version list unavailable';
         });
 
+      // Download links — both use blob to force download regardless of content-type
+      const downloadYaml = document.getElementById('download-yaml');
+      const downloadJson = document.getElementById('download-json');
+
+      function updateDownloadLinks() {}
+
+      async function triggerDownload(content, filename, type) {
+        const blob = new Blob([content], { type });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        a.click();
+        URL.revokeObjectURL(url);
+      }
+
+      downloadYaml.addEventListener('click', async (e) => {
+        e.preventDefault();
+        const resp = await fetch(activeUrl);
+        const text = await resp.text();
+        const filename = (activeUrl.split('/').pop() || 'openapi').replace(/\.json$/, '.yaml');
+        triggerDownload(text, filename, 'application/yaml');
+      });
+
+      downloadJson.addEventListener('click', async (e) => {
+        e.preventDefault();
+        const resp = await fetch(activeUrl);
+        const yamlText = await resp.text();
+        const obj = jsyaml.load(yamlText);
+        const json = JSON.stringify(obj, null, 2);
+        const filename = (activeUrl.split('/').pop() || 'openapi').replace(/\.yaml$/, '.json');
+        triggerDownload(json, filename, 'application/json');
+      });
+
+      updateDownloadLinks();
+
       versionSelect.addEventListener('change', () => {
         activeUrl = versionSelect.value;
         specUrlInput.value = '';
         scalar.updateConfiguration(buildConfig());
+        updateDownloadLinks();
       });
 
       // URL input — overrides the dropdown
@@ -289,6 +346,7 @@ const description = "Interactive explorer for the FusionAuth API.";
         activeUrl = url;
         versionSelect.value = '';
         scalar.updateConfiguration(buildConfig());
+        updateDownloadLinks();
       }
 
       specUrlLoad.addEventListener('click', loadCustomUrl);

--- a/astro/src/pages/docs/apis/api-explorer.astro
+++ b/astro/src/pages/docs/apis/api-explorer.astro
@@ -181,6 +181,10 @@ const description = "Interactive explorer for the FusionAuth API.";
           height: calc(100vh - 105px) !important;
         }
 
+        #scalar-app [id] {
+          scroll-margin-top: 105px !important;
+        }
+
         #scalar-app input[type="text"],
         #scalar-app input[type="password"],
         #scalar-app input:not([type]) {

--- a/astro/src/pages/docs/apis/api-explorer.astro
+++ b/astro/src/pages/docs/apis/api-explorer.astro
@@ -21,7 +21,7 @@ const description = "Interactive explorer for the FusionAuth API.";
       top: 65px;
       left: 0;
       right: 0;
-      z-index: 1000;
+      z-index: 40;
       height: 40px;
       display: flex;
       align-items: center;


### PR DESCRIPTION
## Summary

- Fixed z-index on the versioning navbar so it no longer clips the FusionAuth nav dropdown
- Replaced Scalar's native "Download OpenAPI Document" dropdown with plain YAML and JSON download links in the navbar (both version-aware via blob download)
- Removed the "paste a raw OpenAPI YAML URL" input box from the navbar
- Fixed sidebar anchor links being hidden behind sticky navbar (`scroll-margin-top`)
- Improved badge pill vertical alignment
- Updated `api-explorer-guide.mdx` and `build-openapi.mjs` description to reflect removed UI elements