### PR TITLE
Make validate-code-snippets fail on Bluehawk errors

### DIFF
--- a/astro/package.json
+++ b/astro/package.json
@@ -13,7 +13,7 @@
 		"lint": "eslint",
 		"lint-pr": "node ../src/scripts/lint-recent-files.mjs",
 		"test-code-examples": "bash ../src/scripts/test-code-examples.sh",
-		"validate-code-snippets": "npx --yes bluehawk check --plugin bluehawk-languages.js --ignore 'node_modules' --ignore '.gitignore' --ignore '.DS_Store' --ignore 'package*.json' --ignore '*.lock' --ignore 'repositoryUrl.txt' --ignore 'tests' --ignore 'LICENSE' --ignore 'SECURITY.md' src/code-example-repositories 2>&1 | grep -v 'parsed file' | grep -v 'found binary file' || true"
+		"validate-code-snippets": "out=$(npx --yes bluehawk check --plugin bluehawk-languages.js --ignore 'node_modules' --ignore '.gitignore' --ignore '.DS_Store' --ignore 'package*.json' --ignore '*.lock' --ignore 'repositoryUrl.txt' --ignore 'tests' --ignore 'LICENSE' --ignore 'SECURITY.md' src/code-example-repositories 2>&1); status=$?; printf '%s\\n' \"$out\" | grep -v 'parsed file' | grep -v 'found binary file'; exit $status"
 	},
 	"dependencies": {
 		"@astro-community/astro-embed-youtube": "^0.5.10",


### PR DESCRIPTION
Fixes the `validate-code-snippets` CI gate, which could never fail (target: `ritza/update-bluehawk-pipeline`).

- **Failure mode:** a broken Bluehawk annotation (e.g. a missing `:snippet-end:`) makes `bluehawk check` report errors, but the npm script exited `0` (green). Its exit code was grep's, not bluehawk's, so `validate-code-snippets.yml` passed regardless of errors.
- **Fix:** capture bluehawk's exit code, then filter noise, then exit with it — `out=$(bluehawk check …); status=$?; printf '%s\n' "$out" | grep -v … ; exit $status` (replaces the ` | grep … || true` tail). One-line change, no new files, POSIX `sh`-portable.
- **Verified with real runs:** two distinct error classes (unterminated snippet, orphan `:snippet-end:`) → exit `1`; clean tree → exit `0`; confirmed under `/bin/sh` and that npm propagates the code