### PR TITLE
Fix duplicate url attribute on RemoteCode in webauthn-passkeys.mdx

### DIFF
--- a/astro/src/content/docs/lifecycle/authenticate-users/passwordless/webauthn-passkeys.mdx
+++ b/astro/src/content/docs/lifecycle/authenticate-users/passwordless/webauthn-passkeys.mdx
@@ -290,7 +290,7 @@ See the [`/api/webauthn/start`](/docs/apis/webauthn/start-a-webauthn-passkey-ass
 
 You can use the following JavaScript function to perform the conversion:
 
-<RemoteCode lang="javascript" url="Function to convert a base64url-encoded string to an `ArrayBuffer`" url="https://raw.githubusercontent.com/FusionAuth/fusionauth-example-javascript-webauthn/main/base64url-to-buffer.js" />
+<RemoteCode lang="javascript" title="Function to convert a base64url-encoded string to an `ArrayBuffer`" url="https://raw.githubusercontent.com/FusionAuth/fusionauth-example-javascript-webauthn/main/base64url-to-buffer.js" />
 
 The following is an ES6 JavaScript snippet to convert the API response to the object that is passed to the [WebAuthn JavaScript API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API). In the following example `options` is the value of the **options** field on the [`/api/webauthn/start`](/docs/apis/webauthn/start-a-webauthn-passkey-assertion-or-authentication) API response, and `requestOptions` is the object that is passed to the WebAuthn JavaScript API's `navigator.credentials.get()` function.
 


### PR DESCRIPTION
## Summary
- Scope-checked the WebAuthn item from the Bluehawk revisit queue: `fusionauth-example-javascript-webauthn` is not a login-flow quickstart with a doc guide — it's a small JS helper library (two base64url/ArrayBuffer conversion functions) listed as an "Example App" in `exampleapps.json`, with its own real Jest unit tests. It already uses `LocalCode`-equivalent conventions for its own repo and Node 26; nothing in the Phase 1/2/3 quickstart-migration shape applies to it directly.
- While confirming that scope, found the helper functions ARE referenced from a real, substantive guide: `docs/lifecycle/authenticate-users/passwordless/webauthn-passkeys.mdx`, via `RemoteCode` (not yet Bluehawk-migrated, pulling live from `raw.githubusercontent.com`). One of the 4 `RemoteCode` usages there had a real bug: a duplicate `url=` attribute where a `title=` was clearly intended (the first value was descriptive text, not a URL). Astro/JSX resolves duplicate attributes to the last one, so the component still fetched the correct remote code — but the title caption never rendered above that code block.
- Fixed the typo (`url=` → `title=`); confirmed this was the only instance of the pattern anywhere in the docs tree.

## Test plan
- [x] Ran the existing `tests/test.sh` (Jest unit tests for both helper functions): all 6 tests pass
- [x] Verified via a small script that all 4 `RemoteCode` tags in `webauthn-passkeys.mdx` now have exactly one `url=` attribute each
- [x] Confirmed via `gh api` that the vendored helper files differ from upstream only by expected Bluehawk snippet markers (`:snippet-start:`/`:snippet-end:`/`:remove:`), i.e. no vendoring drift